### PR TITLE
fix(configure) deis_auth_key arrives as a full path by default

### DIFF
--- a/options/provider/aws.sh
+++ b/options/provider/aws.sh
@@ -25,6 +25,10 @@ function aws-setup-keypair {
     aws ec2 import-key-pair --key-name deis \
         --public-key-material file://${deis_auth_key}.pub \
         --output text
+
+    if [ $? -ne 0 ]; then
+      rerun_die $? "ec2 import-key-pair failed: file://${deis_auth_key}.pub"
+    fi
   fi
 }
 

--- a/options/provider/aws.sh
+++ b/options/provider/aws.sh
@@ -23,7 +23,7 @@ function aws-setup-keypair {
   if ! aws ec2 describe-key-pairs --key-names "deis" >/dev/null ; then
     rerun_log "Importing ${deis_auth_key} keypair to EC2"
     aws ec2 import-key-pair --key-name deis \
-        --public-key-material file://~/.ssh/${deis_auth_key}.pub \
+        --public-key-material file://${deis_auth_key}.pub \
         --output text
   fi
 }


### PR DESCRIPTION
I took the defaults from `rigger configure` and the key upload process fails. The subsequent CloudFormation stack fails to boot due to a missing keypair.

Before:

```
Importing /Users/jhansen/.ssh/deis-test keypair to EC2

Error parsing parameter '--public-key-material': Unable to load paramfile file://~/.ssh//Users/jhansen/.ssh/deis-test.pub: [Errno 2] No such file or directory: '/Users/jhansen/.ssh//Users/jhansen/.ssh/deis-test.pub'
Provisioning 3-node CoreOS
arn:aws:cloudformation:us-west-2:XXXXXXXXXXXX:stack/deis-test-XXXXXXXXXX/XXXXXXXX
Waiting for instances to be provisioned (CREATE_IN_PROGRESS, 600s) ...
Waiting for instances to be provisioned (CREATE_IN_PROGRESS, 590s) ...
Waiting for instances to be provisioned (CREATE_IN_PROGRESS, 580s) ...
Waiting for instances to be provisioned (CREATE_IN_PROGRESS, 570s) ...
Waiting for instances to be provisioned (CREATE_IN_PROGRESS, 560s) ...
Waiting for instances to be provisioned (CREATE_IN_PROGRESS, 550s) ...
error creating stack:
VPCSecurityGroupIngress Resource creation cancelled
CoreOSServerLaunchConfig    The key pair 'deis' does not exist
```

After:

```
Importing /Users/jhansen/.ssh/deis-test keypair to EC2
df:aa:31:5f:78:3a:69:7c:17:d7:b5:29:7e:82:a7:9c deis
Provisioning 3-node CoreOS
...
Waiting for instances to pass initial health checks (430s) ...
Waiting for instances to pass initial health checks (420s) ...
Instances are available:
i-X X.X.X.X m3.medium   us-west-2b  running
```
