### PR TITLE
fix([tests,registry]): don't execute docker-machine on linux

### DIFF
--- a/config/defaults.sh
+++ b/config/defaults.sh
@@ -1,4 +1,4 @@
-export RIGGER_HOME="${HOME}/.rigger"
+export RIGGER_HOME="${RIGGER_HOME:-${HOME}/.rigger}"
 
 export UPGRADER_DIR="${RIGGER_ROOT}/options/upgrade-style"
 

--- a/lib/os.sh
+++ b/lib/os.sh
@@ -9,3 +9,9 @@ function which-os {
     echo "windows"
   fi
 }
+
+function get-machine-ip {
+  ifconfig $({ route get 4.2.2.2 || route -n; } 2>/dev/null | \
+    awk '/UG/ {print $8}; /interface:/ {print $2}' | head -n 1
+  ) | awk '/inet / {print $2}' | sed -e 's/addr://'
+}

--- a/lib/registry.sh
+++ b/lib/registry.sh
@@ -1,7 +1,8 @@
 function activate-docker-machine-env {
-  eval "$(docker-machine env deis-registry)"
-
-  save-vars DOCKER_TLS_VERIFY DOCKER_HOST DOCKER_CERT_PATH DOCKER_MACHINE_NAME
+  if [ $(which-os) == darwin ]; then
+    eval "$(docker-machine env deis-registry)"
+    save-vars DOCKER_TLS_VERIFY DOCKER_HOST DOCKER_CERT_PATH DOCKER_MACHINE_NAME
+  fi
 }
 
 function create-dev-registry {
@@ -11,7 +12,8 @@ function create-dev-registry {
     make dev-registry > /dev/null
   )
 
-  export DEV_REGISTRY="$(docker-machine ip deis-registry):5000"
+  local host_ip="${HOST_IPADDR:-$(get-machine-ip)}"
+  export DEV_REGISTRY="${host_ip}:5000"
   save-vars DEV_REGISTRY
 }
 

--- a/tests/configure-1-test.sh
+++ b/tests/configure-1-test.sh
@@ -7,17 +7,18 @@
 
 describe "configure"
 
+TMP=$(mktemp -d "/tmp/rigger_test_root.XXX")
+export RIGGER_HOME="${TMP}"
+
+trap "rm -rf ${TMP}" EXIT
+
 it_fails_to_load_existing_config() {
   # needs file to exist
-  ! rigger configure --type existing --file /tmp/deis/nothing-here-to-see
-}
-
-xit_can_configure_against_existing_cluster() {
-  DEIS_VERSION="1.9.0" DEISCTL_TUNNEL="127.0.0.1" ../rerun deis:configure --type existing
+  ! rigger configure --file /tmp/deis/nothing-to-see-here
 }
 
 it_loads_existing_config() {
-  local temp_vars_file="$(mktemp /tmp/deis-test-vars.XXX)"
+  local temp_vars_file="$(mktemp ${TMP}/rigger_existing_config.XXX)"
 
   cat <<EOF > "${temp_vars_file}"
 GOPATH="${HOME}"
@@ -30,7 +31,7 @@ EOF
 }
 
 function check-file-for-extras {
-  local temp_vars_file="$(mktemp /tmp/deis-test-vars.XXX)"
+  local temp_vars_file="$(mktemp /${TMP}/file_extras_test.XXX)"
 
   rigger shellinit > "${temp_vars_file}"
 

--- a/tests/os-1-test.sh
+++ b/tests/os-1-test.sh
@@ -22,3 +22,11 @@ it_identifies_os() {
 
   [ $(which-os) == "linux" ]
 }
+
+it_identifies_machines_ip() {
+  local ip=$(get-machine-ip)
+
+  # 127 would imply localhost
+  # 172 would imply default docker bridge
+  ! [[ ${ip} =~ (127)|(172).* ]]
+}

--- a/tests/platform-1-test.sh
+++ b/tests/platform-1-test.sh
@@ -9,7 +9,9 @@ describe "platform"
 
 source ../lib/platform.sh
 
-TEST_ROOT="$(mktemp -d /tmp/roundup-test.XXX)"
+TEST_ROOT="$(mktemp -d /tmp/platform-test.XXX)"
+
+trap "rm -rf ${TEST_ROOT}" EXIT
 
 it_deploys_deis_platform() {
 

--- a/tests/shell-reset-1-test.sh
+++ b/tests/shell-reset-1-test.sh
@@ -9,6 +9,8 @@ describe "shell-reset"
 
 it_would_unset_all_vars_but_path() {
   local varsfile="$(mktemp /tmp/tempvars.XXXX)"
+  trap "rm ${varsfile}" EXIT
+
   cat <<EOF > "${varsfile}"
 export PATH="mypath!:saveit!"
 export DEIS_ROOT="some_path_here"


### PR DESCRIPTION
- add some smarts about the machine's main ip address
- clean up unit test droppings
- don't allow unit tests to change current rigger environment
