### PR TITLE
feat(platform): use deisci artifacts if they exist

### DIFF
--- a/config/defaults.sh
+++ b/config/defaults.sh
@@ -5,6 +5,7 @@ export UPGRADER_DIR="${RIGGER_ROOT}/options/upgrade-style"
 export RIGGER_CURRENT_ENV="${RIGGER_HOME}/vars"
 
 export TERRAFORM_DIR="${RIGGER_HOME}/terraform"
+export EXTERNAL_BIN_DIR="${RIGGER_HOME}/bins"
 
 export DEIS_ID=${DEIS_ID:-$(openssl rand -hex 5)}
 export DEIS_ID_DIR="${RIGGER_HOME}/${DEIS_ID}"
@@ -20,4 +21,4 @@ export DEISCLI_BIN="${DEIS_BIN_DIR}/deis"
 export DEISCTL_BIN="${DEIS_BIN_DIR}/deisctl"
 export DEISCTL_UNITS="${RIGGER_HOME}/units"
 
-export PATH="${RIGGER_ROOT}/bin:${PATH}"
+export PATH="${RIGGER_ROOT}/bin:${EXTERNAL_BIN_DIR}:${PATH}"

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -18,6 +18,15 @@ then
     }
 fi
 
+
+
+function install-bin-deps {
+  export PATH="${EXTERNAL_BIN_DIR}:${PATH}"
+  save-vars PATH
+
+  install-jq
+}
+
 function check-registry {
   if ! curl -s "${DEV_REGISTRY}" 1> /dev/null && ! curl -s "https://${DEV_REGISTRY}" 1> /dev/null; then
     rerun_log error "DEV_REGISTRY is not accessible, exiting..."
@@ -65,6 +74,8 @@ function source-shared {
 
 function source-defaults {
   source "config/defaults.sh"
+
+  install-bin-deps
 }
 
 function source-config {

--- a/lib/jq.sh
+++ b/lib/jq.sh
@@ -1,0 +1,39 @@
+function install-jq {
+  local os="$(uname | tr '[:upper:]' '[:lower:]')"
+  local arch="$(uname -m)"
+  local version="1.5"
+  local jq_base_url="https://github.com/stedolan/jq/releases/download/jq-${version}"
+
+  if [ -f "${EXTERNAL_BIN_DIR}/jq" ]; then
+    return 0
+  fi
+
+  case ${arch} in
+    x86_64)
+      if [ ${os} == darwin ]; then
+        arch=amd64
+      elif [ ${os} == linux ]; then
+        arch=64
+      fi
+      ;;
+    *)
+      rerun_die "${arch} is not a currently supported combination between rigger/jq"
+      ;;
+  esac
+
+  case ${os} in
+    darwin)
+      jq_bin_name="jq-osx-${arch}"
+      ;;
+    linux)
+      jq_bin_name="jq-linux${arch}"
+      ;;
+    *)
+      rerun_die "${os} is not a currently supported combination between rigger/jq"
+      ;;
+  esac
+
+  mkdir -p "${EXTERNAL_BIN_DIR}"
+  curl -L "${jq_base_url}/${jq_bin_name}" -o "${EXTERNAL_BIN_DIR}/jq"
+  chmod +x "${EXTERNAL_BIN_DIR}/jq"
+}


### PR DESCRIPTION
To speed up provisions + tests (for humans and for CI)... I've added the ability for rigger to inspect the Deis repository in such a way that if the repo doesn't contain any changes (is not dirty) and the same sha is available on Docker Hub (via the deisci user)... the deis deploy process within rigger will use the Docker Hub Docker images instead of building locally.
