### PR TITLE
fix(ssh-keys): generate DEIS_TEST_AUTH_KEY_FULL if it doesn't exist

### DIFF
--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -142,8 +142,8 @@ function save-vars {
 
 function setup-ssh-agent {
   # generate ssh keys if they don't already exist
-  if [ ! -f "${DEIS_TEST_AUTH_KEY}" ]; then
-    ssh-keygen -t rsa -f "${DEIS_TEST_AUTH_KEY}" -N ''
+  if [ ! -f "${DEIS_TEST_AUTH_KEY_FULL}" ]; then
+    ssh-keygen -t rsa -f "${DEIS_TEST_AUTH_KEY_FULL}" -N ''
   fi
 
   if [ ! -f ${HOME}/.ssh/deiskey ]; then


### PR DESCRIPTION
Using DEIS_TEST_AUTH_KEY_FULL is a workaround in rigger until I can get better key support worked into our integration tests in Deis proper.
