### PR TITLE
Fixes never finding ssh keys

### DIFF
--- a/lib/interactive.sh
+++ b/lib/interactive.sh
@@ -145,7 +145,7 @@ function index-of {
 }
 
 function list-private-keys {
-  find "${HOME}/.ssh" -type f -exec grep -l 'PRIVATE KEY[-]*$' {} \;
+  find "${HOME}/.ssh/" -type f -exec grep -l 'PRIVATE KEY[-]*$' {} \;
 }
 
 function ssh-private-key-prompt {


### PR DESCRIPTION
This may not be an issue for other systems, but on my OSX machine without the slash lines 158-161 became a neverending loop because it wasn't looking in the actual folder for the keys. If other systems behave differently please let me know and I'll work on a better fix.
